### PR TITLE
修复当设置setPage的orientation参数为L时出现的高度和宽度错误的bug

### DIFF
--- a/core/report.go
+++ b/core/report.go
@@ -353,7 +353,6 @@ func (report *Report) SetPage(size string, orientation string) {
 	// report.pageStartY = config.startY
 	// report.pageEndX = config.endX
 	// report.pageEndY = config.endY
-	report.config = config
 
 	report.execute(false)
 }
@@ -368,6 +367,16 @@ func (report *Report) setConfig(width, height, contentWidth, contentHeight, star
 	report.pageStartY = startY
 	report.pageEndX = endX
 	report.pageEndY = endY
+	report.config = &Config{
+		startX:        startX,
+		startY:        startY,
+		endX:          endX,
+		endY:          endY,
+		width:         width,
+		height:        height,
+		contentWidth:  contentWidth,
+		contentHeight: contentHeight,
+	}
 }
 
 // 获取底层的所有的原子单元内容

--- a/core/report.go
+++ b/core/report.go
@@ -320,38 +320,54 @@ func (report *Report) SetPage(size string, orientation string) {
 		switch orientation {
 		case "P":
 			report.addAtomicCell("P|" + unit + "|A4|P")
-			report.pageWidth = config.width
-			report.pageHeight = config.height
+			// report.pageWidth = config.width
+			// report.pageHeight = config.height
+			report.setConfig(config.width, config.height, config.contentWidth, config.contentHeight, config.startX, config.startY, config.endX, config.endY)
 		case "L":
 			report.addAtomicCell("P|" + unit + "|A4|L")
 			report.pageWidth = config.height
 			report.pageHeight = config.width
+			report.setConfig(config.height, config.width, config.contentHeight, config.contentWidth, config.startY, config.startX, config.endY, config.endX)
 		}
 	case "LTR":
 		switch orientation {
 		case "P":
 			report.pageWidth = config.width
 			report.pageHeight = config.height
+			report.setConfig(config.width, config.height, config.contentWidth, config.contentHeight, config.startX, config.startY, config.endX, config.endY)
 			report.addAtomicCell("P|" + unit + "|" + strconv.FormatFloat(report.pageWidth, 'f', 4, 64) +
 				"|" + strconv.FormatFloat(report.pageHeight, 'f', 4, 64))
 		case "L":
 			report.pageWidth = config.height
 			report.pageHeight = config.width
+			report.setConfig(config.height, config.width, config.contentHeight, config.contentWidth, config.startY, config.startX, config.endY, config.endX)
 			report.addAtomicCell("P  |" + unit + "|" + strconv.FormatFloat(report.pageWidth, 'f', 4, 64) +
 				"|" + strconv.FormatFloat(report.pageHeight, 'f', 4, 64))
 		}
 	}
 
-	report.contentWidth = config.contentWidth
-	report.contentHeight = config.contentHeight
+	// report.contentWidth = config.contentWidth
+	// report.contentHeight = config.contentHeight
 
-	report.pageStartX = config.startX
-	report.pageStartY = config.startY
-	report.pageEndX = config.endX
-	report.pageEndY = config.endY
+	// report.pageStartX = config.startX
+	// report.pageStartY = config.startY
+	// report.pageEndX = config.endX
+	// report.pageEndY = config.endY
 	report.config = config
 
 	report.execute(false)
+}
+
+func (report *Report) setConfig(width, height, contentWidth, contentHeight, startX, startY, endX, endY float64) {
+	report.pageWidth = width
+	report.pageHeight = height
+	report.contentWidth = contentWidth
+	report.contentHeight = contentHeight
+
+	report.pageStartX = startX
+	report.pageStartY = startY
+	report.pageEndX = endX
+	report.pageEndY = endY
 }
 
 // 获取底层的所有的原子单元内容


### PR DESCRIPTION
当Report的setPage的orientation参数设置为L时.未正确的设置页面的高度和宽度,导致页面显示不正确,数据出现缺失
当Report的setPage的orientation参数设置为L时，页脚展示异常 #16 